### PR TITLE
Fix `haml-lint` configuration

### DIFF
--- a/lib/cch/config/runners.rb
+++ b/lib/cch/config/runners.rb
@@ -3,7 +3,7 @@ Cch::Setup.tap do |setup|
     runner.watch(/\.rb$/)
   end
 
-  setup.add_runner :haml_lint do |runner|
+  setup.add_runner :haml_lint, gem: 'haml-lint' do |runner|
     runner.watch(/\.haml$/)
   end
 

--- a/lib/cch/runner.rb
+++ b/lib/cch/runner.rb
@@ -6,9 +6,9 @@ module Cch
     attr_reader :name, :patterns
     attr_accessor :command, :on
 
-    def initialize(name)
+    def initialize(name, options = {})
       @name = name
-      @command = "bundle exec #{name} %{files}"
+      @command = "bundle exec #{options[:gem] || name} %{files}"
       @on = false
       @patterns = {}
     end

--- a/lib/cch/setup.rb
+++ b/lib/cch/setup.rb
@@ -14,9 +14,9 @@ module Cch
         ATTRIBUTES.map { |f| "     #{f} = #{send(f)}" }.join("\n")
       end
 
-      def add_runner(runner)
+      def add_runner(runner, options = {})
         @runners ||= {}
-        @runners[runner] = Runner.new(runner)
+        @runners[runner] = Runner.new(runner, options)
         yield @runners[runner] if block_given?
       end
 


### PR DESCRIPTION
- [x] new feature for configuring the gem name
- [x] use the gem hame-lint

fix #6
